### PR TITLE
🐛 fix: make math tips work in non-furo themes

### DIFF
--- a/src/sphinx_tippy.py
+++ b/src/sphinx_tippy.py
@@ -397,7 +397,12 @@ def create_id_to_tip_html(
         ):
             id_to_html[str(tag["id"])] = _get_header_html(header)
 
-        elif tag.name == "div" and "math-wrapper" in (tag.get("class") or []):
+        elif tag.name == "div" and (
+            all(
+                class_to_check in (tag.get("class") or [])
+                for class_to_check in ("math", "notranslate", "nohighlight")
+            )
+        ):
             # remove an span with eqno class, since it is not needed
             # and it can cause issues with the tooltip
             # (e.g. if the span is the last element in the div)


### PR DESCRIPTION
# Fix the Equation hover in other themes

The math reference hover tips only work in furo theme, but not for other themes.

and It has been observed by other users, [like this](https://github.com/executablebooks/jupyter-book/issues/1297#issuecomment-1553338677)

It‘s caused by "filter the div with class 'math-wrapper' to build id_to_html". The 'math-wrapper' class is provided by furo theme but not by the mathjax extension. So in other themes, we will miss the equation element and fail to build the tips.

This commit aims to change the filter to div with class "math", "notranslate" and "no highlight", which is provieded by mathjax extension. and make the math preview work in other themes.

## Visualzation test

### before

![5a6836dc6b7291522a41fe1c91e97aa](https://github.com/sphinx-extensions2/sphinx-tippy/assets/42485228/7f204bbe-d12e-4b25-a588-6bdb0f298830)

With Furo

![b6180819b4b8c0dfaf22f1371fdfdf6](https://github.com/sphinx-extensions2/sphinx-tippy/assets/42485228/00c2c6aa-bb52-4c17-bdaf-423a3beb97dc)

With classic

### After

![012986c7bbbbb549d1fefeec6240c60](https://github.com/sphinx-extensions2/sphinx-tippy/assets/42485228/4f15829b-fde3-473e-9299-74343f949230)

With Furo

![35102209d8d6f4863f9507f19473ca3](https://github.com/sphinx-extensions2/sphinx-tippy/assets/42485228/7302c567-7829-4bf6-a11e-7017b83b135b)

With classic

## References

[Furo init function code that adds math-wrapper div](https://github.com/pradyunsg/furo/blob/e16ca0133061beb619f81cb9f1d1bc1024139a30/src/furo/__init__.py#L61)

[sphinx ext mathjax code that adds those three class](https://github.com/sphinx-doc/sphinx/blob/49d1e7142eca6d303f1e929bdbe9d8e4749858b7/sphinx/ext/mathjax.py#L42)