### PR TITLE
Resolve parallel build issue

### DIFF
--- a/src/sphinx_tippy.py
+++ b/src/sphinx_tippy.py
@@ -131,7 +131,9 @@ def compile_config(app: Sphinx):
     updates = app.config.tippy_props or {}
     if not isinstance(updates, dict):
         raise ExtensionError(f"tippy_props must be a dictionary, not a {type(updates)}")
-    props = dict({"placement": "auto-start", "maxWidth": 500, "interactive": False}, **updates)
+    props = dict(
+        {"placement": "auto-start", "maxWidth": 500, "interactive": False}, **updates
+    )
 
     supported_properties = {
         "placement",
@@ -164,11 +166,15 @@ def compile_config(app: Sphinx):
         "left-end",
     }
     if props["placement"] not in allowed_placements:
-        raise ExtensionError(f"tippy_props['placement'] must one of {allowed_placements}")
+        raise ExtensionError(
+            f"tippy_props['placement'] must one of {allowed_placements}"
+        )
     props["placement"] = f"'{props['placement']}'"
     if not (props["maxWidth"] is None or isinstance(props["maxWidth"], int)):
         raise ExtensionError("tippy_props['maxWidth'] must be an integer or None")
-    props["maxWidth"] = "'none'" if props["maxWidth"] is None else str(props["maxWidth"])
+    props["maxWidth"] = (
+        "'none'" if props["maxWidth"] is None else str(props["maxWidth"])
+    )
     if not isinstance(props["interactive"], bool):
         raise ExtensionError("tippy_props['interactive'] must be a boolean")
     props["interactive"] = "true" if props["interactive"] else "false"
@@ -338,9 +344,13 @@ def collect_tips(
     # TODO ideally here, we would just add a query string to the script load
     # see: https://github.com/sphinx-doc/sphinx/issues/11133
     parts = pagename.split("/")
-    for old_path in Path(app.outdir, "_static", "tippy", *parts).parent.glob(f"{parts[0]}.*.js"):
+    for old_path in Path(app.outdir, "_static", "tippy", *parts).parent.glob(
+        f"{parts[0]}.*.js"
+    ):
         old_path.unlink()
-    js_path = Path(app.outdir, "_static", "tippy", *(pagename + f".{uuid4()}.js").split("/"))
+    js_path = Path(
+        app.outdir, "_static", "tippy", *(pagename + f".{uuid4()}.js").split("/")
+    )
 
     # store the data for later use
     tippy_data = get_tippy_data(app)
@@ -358,7 +368,9 @@ def collect_tips(
     # add the JS files
     for js_file in tippy_config.js_files:
         app.add_js_file(js_file, loading_method="defer")
-    app.add_js_file(str(js_path.relative_to(Path(app.outdir, "_static"))), loading_method="defer")
+    app.add_js_file(
+        str(js_path.relative_to(Path(app.outdir, "_static"))), loading_method="defer"
+    )
 
 
 def create_element_id_map(doctree: nodes.document) -> dict[str, str]:
@@ -381,7 +393,9 @@ def create_element_id_map(doctree: nodes.document) -> dict[str, str]:
     return id_map
 
 
-def create_id_to_tip_html(config: TippyConfig, body: BeautifulSoup) -> dict[str | None, str]:
+def create_id_to_tip_html(
+    config: TippyConfig, body: BeautifulSoup
+) -> dict[str | None, str]:
     """Create a mapping of ids to the HTML to show in the tooltip."""
     id_to_html: dict[str | None, str] = {}
 
@@ -416,7 +430,9 @@ def create_id_to_tip_html(config: TippyConfig, body: BeautifulSoup) -> dict[str 
 
                 id_to_html[str(tag["id"])] += str(copy_dd)
 
-        elif tag.name == "section" and (header := tag.find(["h1", "h2", "h3", "h4", "h5", "h6"])):
+        elif tag.name == "section" and (
+            header := tag.find(["h1", "h2", "h3", "h4", "h5", "h6"])
+        ):
             id_to_html[str(tag["id"])] = _get_header_html(header)
 
         elif tag.name == "div" and (
@@ -507,7 +523,9 @@ def generate_wikipedia_tooltip(title: str) -> str:
         thumbnail_url = data["thumbnail"]["source"]
         style = "float:left; margin-right:10px;"
         alt = "Wikipedia thumbnail"
-        extract_html = f'<img src="{thumbnail_url}" alt="{alt}" style="{style}">' + extract_html
+        extract_html = (
+            f'<img src="{thumbnail_url}" alt="{alt}" style="{style}">' + extract_html
+        )
 
     return extract_html
 
@@ -522,9 +540,14 @@ def fetch_wikipedia_tips(app: Sphinx, data: dict[str, TippyPageData]) -> dict[st
     else:
         wiki_cache = {}
     wiki_fetch = {
-        title for page in data.values() for title in page["wiki_titles"] if title not in wiki_cache
+        title
+        for page in data.values()
+        for title in page["wiki_titles"]
+        if title not in wiki_cache
     }
-    for title in status_iterator(wiki_fetch, "Fetching Wikipedia tips", length=len(wiki_fetch)):
+    for title in status_iterator(
+        wiki_fetch, "Fetching Wikipedia tips", length=len(wiki_fetch)
+    ):
         try:
             wiki_cache[title] = generate_wikipedia_tooltip(title)
         except Exception as exc:
@@ -555,7 +578,9 @@ def fetch_doi_tips(app: Sphinx, data: dict[str, TippyPageData]) -> dict[str, str
             doi_cache = json.load(file)
     else:
         doi_cache = {}
-    doi_fetch = {doi for page in data.values() for doi in page["dois"] if doi not in doi_cache}
+    doi_fetch = {
+        doi for page in data.values() for doi in page["dois"] if doi not in doi_cache
+    }
     for doi in status_iterator(doi_fetch, "Fetching DOI tips", length=len(doi_fetch)):
         url = f"{config.doi_api}{doi}"
         try:
@@ -591,7 +616,12 @@ def fetch_rtd_tips(app: Sphinx, data: dict[str, TippyPageData]) -> dict[str, str
             rtd_cache = json.load(file)
     else:
         rtd_cache = {}
-    rtd_fetch = {rtd for page in data.values() for rtd in page["rtd_urls"] if rtd not in rtd_cache}
+    rtd_fetch = {
+        rtd
+        for page in data.values()
+        for rtd in page["rtd_urls"]
+        if rtd not in rtd_cache
+    }
     for rtd in status_iterator(rtd_fetch, "Fetching RTD tips", length=len(rtd_fetch)):
         # see https://docs.readthedocs.io/en/stable/api/v3.html#embed
         # TODO is this all that needs to be done, to escape the rtd url?
@@ -649,8 +679,12 @@ def write_tippy_props_page(
     selector_to_html: dict[str, str] = {}
     for wiki_title in data["wiki_titles"]:
         if wiki_title in wiki_cache:
-            selector_to_html[f'a[href="{WIKI_PATH}{wiki_title}"]'] = wiki_cache[wiki_title]
-            selector_to_html[f'a[href^="{WIKI_PATH}{wiki_title}#"]'] = wiki_cache[wiki_title]
+            selector_to_html[f'a[href="{WIKI_PATH}{wiki_title}"]'] = wiki_cache[
+                wiki_title
+            ]
+            selector_to_html[f'a[href^="{WIKI_PATH}{wiki_title}#"]'] = wiki_cache[
+                wiki_title
+            ]
     for doi in data["dois"]:
         if doi in doi_cache:
             selector_to_html[f'a[href="{DOI_PATH}{doi}"]'] = doi_cache[doi]
@@ -659,7 +693,9 @@ def write_tippy_props_page(
             selector_to_html[f'a[href="{rtd}"]'] = rtd_cache[rtd]
     for refpage, target in data["refs_in_page"]:
         if refpage is not None:
-            relpage = posixpath.normpath(posixpath.relpath(refpage, posixpath.dirname(pagename)))
+            relpage = posixpath.normpath(
+                posixpath.relpath(refpage, posixpath.dirname(pagename))
+            )
             relfolder = posixpath.dirname(relpage)
             if refpage not in tippy_page_data:
                 pass
@@ -681,16 +717,23 @@ def write_tippy_props_page(
         elif target is None:
             selector_to_html['a[href="#"]'] = local_id_to_html[None]
         elif target in local_id_map and local_id_map[target] in local_id_to_html:
-            selector_to_html[f'a[href="#{target}"]'] = local_id_to_html[local_id_map[target]]
+            selector_to_html[f'a[href="#{target}"]'] = local_id_to_html[
+                local_id_map[target]
+            ]
 
     # custom tips take priority over other tips
     selector_to_html.update(
-        {f'a[href="{ref}"]': tippy_config.custom_tips[ref] for ref in data["custom_in_page"]}
+        {
+            f'a[href="{ref}"]': tippy_config.custom_tips[ref]
+            for ref in data["custom_in_page"]
+        }
     )
 
     pselector = tippy_config.anchor_parent_selector
     mathjax = (
-        ("onShow(instance) {MathJax.typesetPromise([instance.popper]).then(() => {});},")
+        (
+            "onShow(instance) {MathJax.typesetPromise([instance.popper]).then(() => {});},"
+        )
         if tippy_config.enable_mathjax and app.builder.math_renderer_name == "mathjax"  # type: ignore[attr-defined]
         else ""
     )

--- a/src/sphinx_tippy.py
+++ b/src/sphinx_tippy.py
@@ -85,8 +85,16 @@ def setup(app: Sphinx):
 
     app.connect("builder-inited", compile_config)
     app.connect("html-page-context", collect_tips, priority=450)  # before mathjax
+    app.connect("env-merge-info", merge_tippy_data)
     app.connect("build-finished", write_tippy_js)
-    return {"version": __version__, "parallel_read_safe": True}
+    # parallel_write_safe must be False because collect_tips stores data during
+    # html-page-context which runs in parallel workers during the write phase.
+    # This data won't be available in the main process for write_tippy_js.
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": False,
+    }
 
 
 LOGGER = getLogger(__name__)
@@ -123,9 +131,7 @@ def compile_config(app: Sphinx):
     updates = app.config.tippy_props or {}
     if not isinstance(updates, dict):
         raise ExtensionError(f"tippy_props must be a dictionary, not a {type(updates)}")
-    props = dict(
-        {"placement": "auto-start", "maxWidth": 500, "interactive": False}, **updates
-    )
+    props = dict({"placement": "auto-start", "maxWidth": 500, "interactive": False}, **updates)
 
     supported_properties = {
         "placement",
@@ -158,15 +164,11 @@ def compile_config(app: Sphinx):
         "left-end",
     }
     if props["placement"] not in allowed_placements:
-        raise ExtensionError(
-            f"tippy_props['placement'] must one of {allowed_placements}"
-        )
+        raise ExtensionError(f"tippy_props['placement'] must one of {allowed_placements}")
     props["placement"] = f"'{props['placement']}'"
     if not (props["maxWidth"] is None or isinstance(props["maxWidth"], int)):
         raise ExtensionError("tippy_props['maxWidth'] must be an integer or None")
-    props["maxWidth"] = (
-        "'none'" if props["maxWidth"] is None else str(props["maxWidth"])
-    )
+    props["maxWidth"] = "'none'" if props["maxWidth"] is None else str(props["maxWidth"])
     if not isinstance(props["interactive"], bool):
         raise ExtensionError("tippy_props['interactive'] must be a boolean")
     props["interactive"] = "true" if props["interactive"] else "false"
@@ -201,8 +203,7 @@ def compile_config(app: Sphinx):
     if app.builder.name != "html":
         return
     if (
-        app.config.tippy_enable_mathjax
-        and app.builder.math_renderer_name != "mathjax"  # type: ignore[attr-defined]
+        app.config.tippy_enable_mathjax and app.builder.math_renderer_name != "mathjax"  # type: ignore[attr-defined]
     ):
         raise ExtensionError("tippy_enable_mathjax=True requires mathjax to be enabled")
 
@@ -231,6 +232,18 @@ def get_tippy_data(app: Sphinx) -> TippyData:
     if not hasattr(app.env, "tippy_data"):
         app.env.tippy_data = {"pages": {}, "wiki_titles": set()}  # type: ignore
     return cast(TippyData, app.env.tippy_data)  # type: ignore
+
+
+def merge_tippy_data(app: Sphinx, env, docnames, other) -> None:
+    """Merge tippy data from parallel workers.
+
+    When Sphinx runs in parallel mode, each worker process has its own
+    environment. This function merges the tippy data from worker processes
+    back into the main process.
+    """
+    tippy_data = get_tippy_data(app)
+    other_data = getattr(other, "tippy_data", {})
+    tippy_data["pages"].update(other_data.get("pages", {}))
 
 
 def collect_tips(
@@ -325,13 +338,9 @@ def collect_tips(
     # TODO ideally here, we would just add a query string to the script load
     # see: https://github.com/sphinx-doc/sphinx/issues/11133
     parts = pagename.split("/")
-    for old_path in Path(app.outdir, "_static", "tippy", *parts).parent.glob(
-        f"{parts[0]}.*.js"
-    ):
+    for old_path in Path(app.outdir, "_static", "tippy", *parts).parent.glob(f"{parts[0]}.*.js"):
         old_path.unlink()
-    js_path = Path(
-        app.outdir, "_static", "tippy", *(pagename + f".{uuid4()}.js").split("/")
-    )
+    js_path = Path(app.outdir, "_static", "tippy", *(pagename + f".{uuid4()}.js").split("/"))
 
     # store the data for later use
     tippy_data = get_tippy_data(app)
@@ -349,9 +358,7 @@ def collect_tips(
     # add the JS files
     for js_file in tippy_config.js_files:
         app.add_js_file(js_file, loading_method="defer")
-    app.add_js_file(
-        str(js_path.relative_to(Path(app.outdir, "_static"))), loading_method="defer"
-    )
+    app.add_js_file(str(js_path.relative_to(Path(app.outdir, "_static"))), loading_method="defer")
 
 
 def create_element_id_map(doctree: nodes.document) -> dict[str, str]:
@@ -374,9 +381,7 @@ def create_element_id_map(doctree: nodes.document) -> dict[str, str]:
     return id_map
 
 
-def create_id_to_tip_html(
-    config: TippyConfig, body: BeautifulSoup
-) -> dict[str | None, str]:
+def create_id_to_tip_html(config: TippyConfig, body: BeautifulSoup) -> dict[str | None, str]:
     """Create a mapping of ids to the HTML to show in the tooltip."""
     id_to_html: dict[str | None, str] = {}
 
@@ -411,9 +416,7 @@ def create_id_to_tip_html(
 
                 id_to_html[str(tag["id"])] += str(copy_dd)
 
-        elif tag.name == "section" and (
-            header := tag.find(["h1", "h2", "h3", "h4", "h5", "h6"])
-        ):
+        elif tag.name == "section" and (header := tag.find(["h1", "h2", "h3", "h4", "h5", "h6"])):
             id_to_html[str(tag["id"])] = _get_header_html(header)
 
         elif tag.name == "div" and (
@@ -504,9 +507,7 @@ def generate_wikipedia_tooltip(title: str) -> str:
         thumbnail_url = data["thumbnail"]["source"]
         style = "float:left; margin-right:10px;"
         alt = "Wikipedia thumbnail"
-        extract_html = (
-            f'<img src="{thumbnail_url}" alt="{alt}" style="{style}">' + extract_html
-        )
+        extract_html = f'<img src="{thumbnail_url}" alt="{alt}" style="{style}">' + extract_html
 
     return extract_html
 
@@ -521,14 +522,9 @@ def fetch_wikipedia_tips(app: Sphinx, data: dict[str, TippyPageData]) -> dict[st
     else:
         wiki_cache = {}
     wiki_fetch = {
-        title
-        for page in data.values()
-        for title in page["wiki_titles"]
-        if title not in wiki_cache
+        title for page in data.values() for title in page["wiki_titles"] if title not in wiki_cache
     }
-    for title in status_iterator(
-        wiki_fetch, "Fetching Wikipedia tips", length=len(wiki_fetch)
-    ):
+    for title in status_iterator(wiki_fetch, "Fetching Wikipedia tips", length=len(wiki_fetch)):
         try:
             wiki_cache[title] = generate_wikipedia_tooltip(title)
         except Exception as exc:
@@ -559,9 +555,7 @@ def fetch_doi_tips(app: Sphinx, data: dict[str, TippyPageData]) -> dict[str, str
             doi_cache = json.load(file)
     else:
         doi_cache = {}
-    doi_fetch = {
-        doi for page in data.values() for doi in page["dois"] if doi not in doi_cache
-    }
+    doi_fetch = {doi for page in data.values() for doi in page["dois"] if doi not in doi_cache}
     for doi in status_iterator(doi_fetch, "Fetching DOI tips", length=len(doi_fetch)):
         url = f"{config.doi_api}{doi}"
         try:
@@ -597,12 +591,7 @@ def fetch_rtd_tips(app: Sphinx, data: dict[str, TippyPageData]) -> dict[str, str
             rtd_cache = json.load(file)
     else:
         rtd_cache = {}
-    rtd_fetch = {
-        rtd
-        for page in data.values()
-        for rtd in page["rtd_urls"]
-        if rtd not in rtd_cache
-    }
+    rtd_fetch = {rtd for page in data.values() for rtd in page["rtd_urls"] if rtd not in rtd_cache}
     for rtd in status_iterator(rtd_fetch, "Fetching RTD tips", length=len(rtd_fetch)):
         # see https://docs.readthedocs.io/en/stable/api/v3.html#embed
         # TODO is this all that needs to be done, to escape the rtd url?
@@ -660,12 +649,8 @@ def write_tippy_props_page(
     selector_to_html: dict[str, str] = {}
     for wiki_title in data["wiki_titles"]:
         if wiki_title in wiki_cache:
-            selector_to_html[f'a[href="{WIKI_PATH}{wiki_title}"]'] = wiki_cache[
-                wiki_title
-            ]
-            selector_to_html[f'a[href^="{WIKI_PATH}{wiki_title}#"]'] = wiki_cache[
-                wiki_title
-            ]
+            selector_to_html[f'a[href="{WIKI_PATH}{wiki_title}"]'] = wiki_cache[wiki_title]
+            selector_to_html[f'a[href^="{WIKI_PATH}{wiki_title}#"]'] = wiki_cache[wiki_title]
     for doi in data["dois"]:
         if doi in doi_cache:
             selector_to_html[f'a[href="{DOI_PATH}{doi}"]'] = doi_cache[doi]
@@ -674,9 +659,7 @@ def write_tippy_props_page(
             selector_to_html[f'a[href="{rtd}"]'] = rtd_cache[rtd]
     for refpage, target in data["refs_in_page"]:
         if refpage is not None:
-            relpage = posixpath.normpath(
-                posixpath.relpath(refpage, posixpath.dirname(pagename))
-            )
+            relpage = posixpath.normpath(posixpath.relpath(refpage, posixpath.dirname(pagename)))
             relfolder = posixpath.dirname(relpage)
             if refpage not in tippy_page_data:
                 pass
@@ -698,26 +681,17 @@ def write_tippy_props_page(
         elif target is None:
             selector_to_html['a[href="#"]'] = local_id_to_html[None]
         elif target in local_id_map and local_id_map[target] in local_id_to_html:
-            selector_to_html[f'a[href="#{target}"]'] = local_id_to_html[
-                local_id_map[target]
-            ]
+            selector_to_html[f'a[href="#{target}"]'] = local_id_to_html[local_id_map[target]]
 
     # custom tips take priority over other tips
     selector_to_html.update(
-        {
-            f'a[href="{ref}"]': tippy_config.custom_tips[ref]
-            for ref in data["custom_in_page"]
-        }
+        {f'a[href="{ref}"]': tippy_config.custom_tips[ref] for ref in data["custom_in_page"]}
     )
 
     pselector = tippy_config.anchor_parent_selector
     mathjax = (
-        (
-            "onShow(instance) "
-            "{MathJax.typesetPromise([instance.popper]).then(() => {});},"
-        )
-        if tippy_config.enable_mathjax
-        and app.builder.math_renderer_name == "mathjax"  # type: ignore[attr-defined]
+        ("onShow(instance) {MathJax.typesetPromise([instance.popper]).then(() => {});},")
+        if tippy_config.enable_mathjax and app.builder.math_renderer_name == "mathjax"  # type: ignore[attr-defined]
         else ""
     )
     # TODO need to only enable when math,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,8 @@
+from unittest.mock import MagicMock
+
 from sphinx_pytest.plugin import CreateDoctree
+
+from sphinx_tippy import merge_tippy_data, setup
 
 
 def test_basic(sphinx_doctree: CreateDoctree, data_regression):
@@ -22,3 +26,67 @@ Test
     for value in result.app.env.tippy_data["pages"].values():
         value.pop("js_path", None)
     data_regression.check(result.app.env.tippy_data)
+
+
+def test_parallel_read_safe():
+    """Test that the extension reports correct parallel safety flags."""
+    app = MagicMock()
+    result = setup(app)
+    assert result["parallel_read_safe"] is True
+    assert result["parallel_write_safe"] is False
+
+
+def test_merge_tippy_data_basic(sphinx_doctree: CreateDoctree):
+    """Test that tippy data merging works with real Sphinx environment."""
+    sphinx_doctree.set_conf({"extensions": ["sphinx_tippy"]})
+    sphinx_doctree.buildername = "html"
+    result = sphinx_doctree(
+        """
+Test Page
+=========
+
+Some content.
+    """,
+    )
+
+    # Simulate data from another worker
+    other_env = MagicMock()
+    other_env.tippy_data = {
+        "pages": {
+            "other_page": {
+                "element_id_map": {"other-id": "other-id"},
+                "id_to_html": {"other-id": "<p>Other content</p>"},
+            },
+        }
+    }
+
+    # Merge the data
+    merge_tippy_data(result.app, result.app.env, [], other_env)
+
+    # Verify both pages exist after merge
+    assert "index" in result.app.env.tippy_data["pages"]
+    assert "other_page" in result.app.env.tippy_data["pages"]
+
+
+def test_merge_tippy_data_empty_other(sphinx_doctree: CreateDoctree):
+    """Test merging when other environment has no tippy data."""
+    sphinx_doctree.set_conf({"extensions": ["sphinx_tippy"]})
+    sphinx_doctree.buildername = "html"
+    result = sphinx_doctree(
+        """
+Test Page
+=========
+
+Some content.
+    """,
+    )
+
+    # Simulate worker with no tippy data
+    other_env = MagicMock(spec=[])  # no tippy_data attribute
+
+    original_pages = set(result.app.env.tippy_data["pages"].keys())
+
+    # Merge should not fail and should preserve existing data
+    merge_tippy_data(result.app, result.app.env, [], other_env)
+
+    assert set(result.app.env.tippy_data["pages"].keys()) == original_pages


### PR DESCRIPTION
RE: #9 
This pull request improves the Sphinx extension's support for parallel builds and code maintainability.

* Added a new `merge_tippy_data` function to correctly merge tooltip data from parallel Sphinx worker processes, and connected it to the `env-merge-info` event in the extension setup.
* Updated the extension's `setup` return value to set `"parallel_write_safe": False`, reflecting that data is collected during the parallel write phase and must be merged afterwards.
* Added tests
* Tested agains the tippy docs: run with `-j auto` flag against main and see on tooltips not working vs against this change.